### PR TITLE
Uses a Laravel set element instead of hard-coding.

### DIFF
--- a/resources/angular/account/register.js
+++ b/resources/angular/account/register.js
@@ -9,7 +9,7 @@ angular.module('fc.account.register', [
    $scope.returnHome = returnHome;
 
    $scope.squarePaymentForm = new SqPaymentForm({
-      applicationId: 'sandbox-sq0idp-ShnGBqDA9ae3V3H6piMkMQ',
+      applicationId: $('meta[name="square_application_id"]').attr('content'),
       inputClass: 'sq-input',
       inputStyles: [{
          fontSize: '15px'

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="csrf_token" content="{{ csrf_token() }}">
+    <meta name="square_application_id" content="{{ config('services.square.app_id') }}">
 
     <title>{{ $title or "Fasting Crusade" }}</title>
 


### PR DESCRIPTION
 This provides the Square application ID to JS pages in a way that keeps
 configuration in one place.